### PR TITLE
Fix IndexOutOfBoundsException on update

### DIFF
--- a/audio/src/main/java/com/visualizer/amplitude/AudioRecordView.kt
+++ b/audio/src/main/java/com/visualizer/amplitude/AudioRecordView.kt
@@ -5,6 +5,7 @@ import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
 import android.util.AttributeSet
+import android.util.Log
 import android.view.View
 import java.util.*
 
@@ -120,8 +121,7 @@ class AudioRecordView : View {
 
         val chunkHorizontalScale = chunkWidth + chunkSpace
         val maxChunkCount = width / chunkHorizontalScale
-
-        if (chunkHeights.size >= maxChunkCount) {
+        if (chunkHeights.isNotEmpty() && chunkHeights.size >= maxChunkCount) {
             chunkHeights.removeAt(0)
         } else {
             usageWidth += chunkHorizontalScale


### PR DESCRIPTION
In some cases  `chunkHeights` and `maxChunkCount` are both 0 so it executes `chunkHeights.removeAt(0)`
that causes the Exception.
Fix #4

